### PR TITLE
LAYOUTS-674 adjust api url before sending request so we bypass varnish

### DIFF
--- a/components/block-picker/element.js
+++ b/components/block-picker/element.js
@@ -1,5 +1,6 @@
 import {LitElement, html} from 'lit';
 import {classMap} from 'lit/directives/class-map.js';
+import { formatApiUrlToBypassCache } from '../component-helper.js';
 import { CloseIcon } from '../icons.js';
 import style from './style.js';
 
@@ -162,16 +163,8 @@ export default class BlockPicker extends LitElement {
     }
   }
 
-  formatApiUrl(url) {
-    const urlObject = new URL(url)
-    let searchParams = new URLSearchParams(urlObject.search)
-    searchParams.set('t', Date.now())
-
-    return `${urlObject.origin + urlObject.pathname}?${searchParams.toString()}`
-  }
-
   async handleRefreshView(blockId) {
-    const apiUrl = this.formatApiUrl(window.location.href)
+    const apiUrl = formatApiUrlToBypassCache(window.location.href)
     return await fetch(apiUrl)
       .then(resp => {
         return resp.text()

--- a/components/block-picker/element.js
+++ b/components/block-picker/element.js
@@ -162,10 +162,17 @@ export default class BlockPicker extends LitElement {
     }
   }
 
+  formatApiUrl(url) {
+    const urlObject = new URL(url)
+    let searchParams = new URLSearchParams(urlObject.search)
+    searchParams.set('t', Date.now())
+
+    return `${urlObject.origin + urlObject.pathname}?${searchParams.toString()}`
+  }
 
   async handleRefreshView(blockId) {
-
-    return await fetch(window.location.href)
+    const apiUrl = this.formatApiUrl(window.location.href)
+    return await fetch(apiUrl)
       .then(resp => {
         return resp.text()
       })

--- a/components/block-picker/element.js
+++ b/components/block-picker/element.js
@@ -1,6 +1,6 @@
 import {LitElement, html} from 'lit';
 import {classMap} from 'lit/directives/class-map.js';
-import { formatApiUrlToBypassCache } from '../component-helper.js';
+import { addTimestampToUrl } from '../component-helper.js';
 import { CloseIcon } from '../icons.js';
 import style from './style.js';
 
@@ -164,7 +164,7 @@ export default class BlockPicker extends LitElement {
   }
 
   async handleRefreshView(blockId) {
-    const apiUrl = formatApiUrlToBypassCache(window.location.href)
+    const apiUrl = addTimestampToUrl(window.location.href)
     return await fetch(apiUrl)
       .then(resp => {
         return resp.text()

--- a/components/block/element.js
+++ b/components/block/element.js
@@ -116,11 +116,19 @@ export default class Block extends LitElement {
   }
   // GETTERS - end
 
+  formatApiUrl(url) {
+    const urlObject = new URL(url)
+    let searchParams = new URLSearchParams(urlObject.search)
+    searchParams.set('t', Date.now())
+
+    return `${urlObject.origin + urlObject.pathname}?${searchParams.toString()}`
+  }
 
   async fetch() {
     this.loading = true;
     try {
-      const resp = await fetch(window.location.href);
+      const apiUrl = this.formatApiUrl(window.location.href)
+      const resp = await fetch(apiUrl);
       return resp.text();
     } finally {
       this.loading = false;
@@ -243,8 +251,6 @@ export default class Block extends LitElement {
   select() {
     if (this.isInLinkedZone) return;
 
-    console.debug(this.model)
-
     this.model.trigger('edit');
     this.isSelected = true;
   }
@@ -339,12 +345,11 @@ export default class Block extends LitElement {
         this.handleRefreshView()
       })
     }
-
   }
 
   async handleRefreshView() {
-
-    return await fetch(window.location.href)
+    const apiUrl = this.formatApiUrl(window.location.href)
+    return await fetch(apiUrl)
       .then(resp => {
         return resp.text()
       })

--- a/components/block/element.js
+++ b/components/block/element.js
@@ -3,6 +3,7 @@ import {classMap} from 'lit/directives/class-map.js';
 import style from './style.js';
 
 import { ArrowDownIcon, ArrowUpIcon, BreadcrumbArrowIcon, PlusIcon, RefreshIcon } from '../icons.js';
+import { formatApiUrlToBypassCache } from '../component-helper.js';
 
 export default class Block extends LitElement {
   static styles = [style];
@@ -115,19 +116,10 @@ export default class Block extends LitElement {
     return this.slottedChildren[0]?.querySelectorAll('ngl-block')
   }
   // GETTERS - end
-
-  formatApiUrl(url) {
-    const urlObject = new URL(url)
-    let searchParams = new URLSearchParams(urlObject.search)
-    searchParams.set('t', Date.now())
-
-    return `${urlObject.origin + urlObject.pathname}?${searchParams.toString()}`
-  }
-
   async fetch() {
     this.loading = true;
     try {
-      const apiUrl = this.formatApiUrl(window.location.href)
+      const apiUrl = formatApiUrlToBypassCache(window.location.href)
       const resp = await fetch(apiUrl);
       return resp.text();
     } finally {
@@ -348,7 +340,7 @@ export default class Block extends LitElement {
   }
 
   async handleRefreshView() {
-    const apiUrl = this.formatApiUrl(window.location.href)
+    const apiUrl = formatApiUrlToBypassCache(window.location.href)
     return await fetch(apiUrl)
       .then(resp => {
         return resp.text()

--- a/components/block/element.js
+++ b/components/block/element.js
@@ -3,7 +3,7 @@ import {classMap} from 'lit/directives/class-map.js';
 import style from './style.js';
 
 import { ArrowDownIcon, ArrowUpIcon, BreadcrumbArrowIcon, PlusIcon, RefreshIcon } from '../icons.js';
-import { formatApiUrlToBypassCache } from '../component-helper.js';
+import { addTimestampToUrl } from '../component-helper.js';
 
 export default class Block extends LitElement {
   static styles = [style];
@@ -119,7 +119,7 @@ export default class Block extends LitElement {
   async fetch() {
     this.loading = true;
     try {
-      const apiUrl = formatApiUrlToBypassCache(window.location.href)
+      const apiUrl = addTimestampToUrl(window.location.href)
       const resp = await fetch(apiUrl);
       return resp.text();
     } finally {
@@ -340,7 +340,7 @@ export default class Block extends LitElement {
   }
 
   async handleRefreshView() {
-    const apiUrl = formatApiUrlToBypassCache(window.location.href)
+    const apiUrl = addTimestampToUrl(window.location.href)
     return await fetch(apiUrl)
       .then(resp => {
         return resp.text()

--- a/components/component-helper.js
+++ b/components/component-helper.js
@@ -1,4 +1,4 @@
-export const formatApiUrlToBypassCache = (url) => {
+export const addTimestampToUrl = (url) => {
   const urlObject = new URL(url)
   let searchParams = new URLSearchParams(urlObject.search)
   searchParams.set('t', Date.now())

--- a/components/component-helper.js
+++ b/components/component-helper.js
@@ -1,0 +1,7 @@
+export const formatApiUrlToBypassCache = (url) => {
+  const urlObject = new URL(url)
+  let searchParams = new URLSearchParams(urlObject.search)
+  searchParams.set('t', Date.now())
+
+  return `${urlObject.origin + urlObject.pathname}?${searchParams.toString()}`
+}


### PR DESCRIPTION
@MarkoZabcic I have same function for formatting the url before request in both block and block picker components. Should extract that function to separate file or is it okay if it stays like this? There are other places in backbone part of layouts where same function is also used. Is there a way to unfiy that part as well?